### PR TITLE
fix: making imageUrl independent of API_HOST_URL formatting

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/container/CourseContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/container/CourseContainerViewModel.kt
@@ -201,7 +201,7 @@ class CourseContainerViewModel(
 
     private fun loadCourseImage(imageUrl: String?) {
         imageProcessor.loadImage(
-            imageUrl = config.getApiHostURL() + imageUrl,
+            imageUrl = config.getApiHostURL().trimEnd('/') + "/" + imageUrl?.removePrefix("/"),
             defaultImage = CoreR.drawable.core_no_image_course,
             onComplete = { drawable ->
                 val bitmap = (drawable as BitmapDrawable).bitmap.apply {

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardFragment.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardFragment.kt
@@ -401,7 +401,7 @@ private fun CourseItem(
             )
         )
     }
-    val imageUrl = apiHostUrl.dropLast(1) + enrolledCourse.course.courseImage
+    val imageUrl = apiHostUrl.trimEnd('/') + "/" + enrolledCourse.course.courseImage.removePrefix("/")
     val context = LocalContext.current
     Surface(
         modifier = Modifier


### PR DESCRIPTION
We are facing issues with how the API_HOST_URL is provided with `/` in the end or not.

This PR removes that dependency for course image URLs.