### PR TITLE
feat: add "Gated" UI state for subsections

### DIFF
--- a/core/src/main/java/org/openedx/core/data/api/CourseApi.kt
+++ b/core/src/main/java/org/openedx/core/data/api/CourseApi.kt
@@ -9,6 +9,7 @@ import org.openedx.core.data.model.CourseEnrollments
 import org.openedx.core.data.model.CourseStructureModel
 import org.openedx.core.data.model.HandoutsModel
 import org.openedx.core.data.model.ResetCourseDates
+import org.openedx.core.data.model.SequenceModel
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -67,4 +68,7 @@ interface CourseApi {
 
     @GET("/api/mobile/v1/course_info/{course_id}/updates")
     suspend fun getAnnouncements(@Path("course_id") courseId: String): List<AnnouncementModel>
+
+    @GET("api/courseware/sequence/{sequence_id}/")
+    suspend fun getSequence(@Path("sequence_id") sequenceId: String): SequenceModel
 }

--- a/core/src/main/java/org/openedx/core/data/model/GatedContentModel.kt
+++ b/core/src/main/java/org/openedx/core/data/model/GatedContentModel.kt
@@ -1,0 +1,28 @@
+package org.openedx.core.data.model
+
+import com.google.gson.annotations.SerializedName
+
+import org.openedx.core.domain.model.GatedContent
+
+data class GatedContentModel(
+    @SerializedName("prereq_id")
+    val prereqId: String?,
+    @SerializedName("prereq_url")
+    val prereqUrl: String?,
+    @SerializedName("prereq_section_name")
+    val prereqSectionName: String?,
+    @SerializedName("gated")
+    val gated: Boolean,
+    @SerializedName("gated_section_name")
+    val gatedSectionName: String?,
+) {
+    fun mapToDomain(): GatedContent {
+        return GatedContent(
+            prereqId = prereqId,
+            prereqUrl = prereqUrl,
+            prereqSubsectionName = prereqSectionName,
+            gated = gated,
+            gatedSubsectionName = gatedSectionName
+        )
+    }
+}

--- a/core/src/main/java/org/openedx/core/data/model/SequenceModel.kt
+++ b/core/src/main/java/org/openedx/core/data/model/SequenceModel.kt
@@ -1,0 +1,31 @@
+package org.openedx.core.data.model
+
+import com.google.gson.annotations.SerializedName
+
+import org.openedx.core.domain.model.Subsection
+
+data class SequenceModel(
+    @SerializedName("element_id")
+    val elementId: String,
+    @SerializedName("item_id")
+    val itemId: String,
+    @SerializedName("banner_text")
+    val bannerText: String?,
+    @SerializedName("gated_content")
+    val gatedContentModel: GatedContentModel,
+    @SerializedName("sequence_name")
+    val sequenceName: String,
+    @SerializedName("display_name")
+    val displayName: String,
+) {
+    fun mapToDomain(): Subsection {
+        return Subsection(
+            elementId = elementId,
+            itemId = itemId,
+            bannerText = bannerText,
+            subsectionName = sequenceName,
+            displayName = displayName,
+            gatedContent = gatedContentModel.mapToDomain(),
+        )
+    }
+}

--- a/core/src/main/java/org/openedx/core/domain/model/GatedContent.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/GatedContent.kt
@@ -1,0 +1,13 @@
+package org.openedx.core.domain.model;
+
+import android.os.Parcelable;
+import kotlinx.parcelize.Parcelize;
+
+@Parcelize
+data class GatedContent(
+    val prereqId: String?,
+    val prereqUrl: String?,
+    val prereqSubsectionName: String?,
+    val gated: Boolean,
+    val gatedSubsectionName: String?
+) : Parcelable;

--- a/core/src/main/java/org/openedx/core/domain/model/Subsection.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/Subsection.kt
@@ -1,0 +1,14 @@
+package org.openedx.core.domain.model;
+
+import android.os.Parcelable;
+import kotlinx.parcelize.Parcelize;
+
+@Parcelize
+data class Subsection(
+    val elementId: String,
+    val itemId: String,
+    val bannerText: String?,
+    val gatedContent: GatedContent,
+    val subsectionName: String,
+    val displayName: String
+) : Parcelable;

--- a/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
+++ b/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
@@ -85,4 +85,6 @@ class CourseRepository(
 
     suspend fun getAnnouncements(courseId: String) =
         api.getAnnouncements(courseId).map { it.mapToDomain() }
+
+    suspend fun getSequence(sectionId: String) = api.getSequence(sectionId).mapToDomain()
 }

--- a/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
+++ b/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
@@ -86,5 +86,5 @@ class CourseRepository(
     suspend fun getAnnouncements(courseId: String) =
         api.getAnnouncements(courseId).map { it.mapToDomain() }
 
-    suspend fun getSequence(sectionId: String) = api.getSequence(sectionId).mapToDomain()
+    suspend fun getSequence(sequenceId: String) = api.getSequence(sequenceId).mapToDomain()
 }

--- a/course/src/main/java/org/openedx/course/domain/interactor/CourseInteractor.kt
+++ b/course/src/main/java/org/openedx/course/domain/interactor/CourseInteractor.kt
@@ -70,6 +70,8 @@ class CourseInteractor(
 
     suspend fun removeDownloadModel(id: String) = repository.removeDownloadModel(id)
 
+    suspend fun getSubsection(subsectionId: String) = repository.getSequence(subsectionId)
+
     fun getDownloadModels() = repository.getDownloadModels()
 
 }

--- a/course/src/main/java/org/openedx/course/presentation/CourseAnalytics.kt
+++ b/course/src/main/java/org/openedx/course/presentation/CourseAnalytics.kt
@@ -77,6 +77,10 @@ enum class CourseAnalyticsEvent(val eventName: String, val biValue: String) {
         "Course:Unit Detail",
         "edx.bi.app.course.unit_detail"
     ),
+    PREREQUISITE(
+        "Course:Prerequisite",
+        "edx.bi.app.course.prerequisite"
+    ),
     VIEW_CERTIFICATE(
         "Course:View Certificate Clicked",
         "edx.bi.app.course.view_certificate.clicked"

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -238,6 +239,34 @@ private fun CourseSectionScreen(
                                 contentAlignment = Alignment.Center
                             ) {
                                 CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                            }
+                        }
+
+                        is CourseSectionUIState.Gated -> {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.Center,
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Image(
+                                    painter = painterResource(id = R.drawable.ic_course_gated),
+                                    contentDescription = "gated",
+                                    modifier = Modifier.size(48.dp)
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                                Text(
+                                    modifier = Modifier
+                                        .padding(horizontal = 16.dp)
+                                        .fillMaxWidth(),
+                                    text = stringResource(
+                                        id = R.string.course_gated_subsection,
+                                        uiState.prereqSubsectionName ?: ""
+                                    ),
+                                    textAlign = TextAlign.Center,
+                                    style = MaterialTheme.appTypography.titleMedium,
+                                    color = MaterialTheme.appColors.textPrimary,
+
+                                )
                             }
                         }
 

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -108,6 +108,15 @@ class CourseSectionFragment : Fragment() {
                                             .replace(Regex("\\s"), "_"), it.id
                             )
                         }
+                    },
+                    onGoToPrerequisiteClick = { subSectionId ->
+                        viewModel.goToPrerequisiteSectionClickedEvent(subSectionId)
+                        router.navigateToCourseSubsections(
+                            fm = requireActivity().supportFragmentManager,
+                            courseId = viewModel.courseId,
+                            subSectionId = subSectionId,
+                            mode = CourseViewMode.FULL
+                        )
                     }
                 )
 
@@ -161,7 +170,8 @@ private fun CourseSectionScreen(
     uiMessage: UIMessage?,
     onBackClick: () -> Unit,
     onItemClick: (Block) -> Unit,
-    onDownloadClick: (Block) -> Unit
+    onDownloadClick: (Block) -> Unit,
+    onGoToPrerequisiteClick: (String) -> Unit
 ) {
     val scaffoldState = rememberScaffoldState()
     val title = when (uiState) {
@@ -265,7 +275,14 @@ private fun CourseSectionScreen(
                                     textAlign = TextAlign.Center,
                                     style = MaterialTheme.appTypography.titleMedium,
                                     color = MaterialTheme.appColors.textPrimary,
-
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                                OpenEdXButton(
+                                    text = stringResource(id = R.string.course_go_to_prerequisite_section),
+                                    onClick = {
+                                        onGoToPrerequisiteClick(uiState.prereqId ?: "")
+                                    },
+                                    modifier = Modifier.padding(top = 16.dp)
                                 )
                             }
                         }
@@ -429,7 +446,8 @@ private fun CourseSectionScreenPreview() {
             uiMessage = null,
             onBackClick = {},
             onItemClick = {},
-            onDownloadClick = {}
+            onDownloadClick = {},
+            onGoToPrerequisiteClick = {}
         )
     }
 }
@@ -455,7 +473,31 @@ private fun CourseSectionScreenTabletPreview() {
             uiMessage = null,
             onBackClick = {},
             onItemClick = {},
-            onDownloadClick = {}
+            onDownloadClick = {},
+            onGoToPrerequisiteClick = {}
+        )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.NEXUS_9)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, device = Devices.NEXUS_9)
+@Composable
+private fun CourseSectionScreenGatedPreview() {
+    OpenEdXTheme {
+        CourseSectionScreen(
+            windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
+            uiState = CourseSectionUIState.Gated(
+                "Gated Subsection",
+                "Prerequisite Subsection",
+                "Prerequisite Id"
+            ),
+            uiMessage = null,
+            onBackClick = {},
+            onItemClick = {},
+            onDownloadClick = {},
+            onGoToPrerequisiteClick = {}
         )
     }
 }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
@@ -10,5 +10,9 @@ sealed class CourseSectionUIState {
         val sectionName: String,
         val courseName: String
     ) : CourseSectionUIState()
+    data class Gated(
+        val gatedSubsectionName: String?,
+        val prereqSubsectionName: String?,
+    ) : CourseSectionUIState()
     object Loading : CourseSectionUIState()
 }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
@@ -13,6 +13,7 @@ sealed class CourseSectionUIState {
     data class Gated(
         val gatedSubsectionName: String?,
         val prereqSubsectionName: String?,
+        val prereqId: String?,
     ) : CourseSectionUIState()
     object Loading : CourseSectionUIState()
 }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
@@ -91,9 +91,10 @@ class CourseSectionViewModel(
                 val sectionData = interactor.getSubsection(blockId)
                 if (sectionData.gatedContent.gated) {
                     _uiState.value = CourseSectionUIState.Gated(
+                        prereqId = sectionData.gatedContent.prereqId,
+                        prereqSubsectionName = sectionData.gatedContent.prereqSubsectionName,
                         gatedSubsectionName = sectionData.gatedContent.gatedSubsectionName,
-                        prereqSubsectionName = sectionData.gatedContent.prereqSubsectionName
-                    )
+                        )
                     return@launch
                 }
                 val courseStructure = when (mode) {
@@ -170,6 +171,21 @@ class CourseSectionViewModel(
                     put(CourseAnalyticsKey.NAME.key, CourseAnalyticsEvent.UNIT_DETAIL.biValue)
                     put(CourseAnalyticsKey.COURSE_ID.key, courseId)
                     put(CourseAnalyticsKey.BLOCK_ID.key, blockId)
+                    put(CourseAnalyticsKey.CATEGORY.key, CourseAnalyticsKey.NAVIGATION.key)
+                }
+            )
+        }
+    }
+
+    fun goToPrerequisiteSectionClickedEvent(subSectionId: String) {
+        val currentState = uiState.value
+        if (currentState is CourseSectionUIState.Gated) {
+            analytics.logEvent(
+                event = CourseAnalyticsEvent.PREREQUISITE.eventName,
+                params = buildMap {
+                    put(CourseAnalyticsKey.NAME.key, CourseAnalyticsEvent.PREREQUISITE.biValue)
+                    put(CourseAnalyticsKey.COURSE_ID.key, courseId)
+                    put(CourseAnalyticsKey.BLOCK_ID.key, subSectionId)
                     put(CourseAnalyticsKey.CATEGORY.key, CourseAnalyticsKey.NAVIGATION.key)
                 }
             )

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
@@ -88,6 +88,14 @@ class CourseSectionViewModel(
         _uiState.value = CourseSectionUIState.Loading
         viewModelScope.launch {
             try {
+                val sectionData = interactor.getSubsection(blockId)
+                if (sectionData.gatedContent.gated) {
+                    _uiState.value = CourseSectionUIState.Gated(
+                        gatedSubsectionName = sectionData.gatedContent.gatedSubsectionName,
+                        prereqSubsectionName = sectionData.gatedContent.prereqSubsectionName
+                    )
+                    return@launch
+                }
                 val courseStructure = when (mode) {
                     CourseViewMode.FULL -> interactor.getCourseStructureFromCache()
                     CourseViewMode.VIDEOS -> interactor.getCourseStructureForVideos()

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="course_resume">Resume</string>
     <string name="course_to_proceed">To proceed with \"%s\" press \"Next section\".</string>
     <string name="course_gated_content_label">Some content in this part of the course is locked for upgraded users only.</string>
+    <string name="course_gated_subsection">Content locked. You must complete the prerequisite: \“%s\” to access this content.</string>
     <string name="course_change_quality_when_downloading">You cannot change the download video quality when all videos are downloading</string>
     <string name="course_dates_shifted_message">Dates Shifted</string>
 

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="course_to_proceed">To proceed with \"%s\" press \"Next section\".</string>
     <string name="course_gated_content_label">Some content in this part of the course is locked for upgraded users only.</string>
     <string name="course_gated_subsection">Content locked. You must complete the prerequisite: \“%s\” to access this content.</string>
+    <string name="course_go_to_prerequisite_section">Go To Prerequisite Section</string>
     <string name="course_change_quality_when_downloading">You cannot change the download video quality when all videos are downloading</string>
     <string name="course_dates_shifted_message">Dates Shifted</string>
 


### PR DESCRIPTION
## Description

Here is what happens when you try to access any section before completing prerequisites in LMS:
![image](https://github.com/user-attachments/assets/7624906f-4dc7-45ee-ab4b-2eb3893b0627)

---

Here is what happens when you try to access any unit in a gated subsection using the mobile app (the first subsection on the video is a prerequisite to the second):


https://github.com/user-attachments/assets/52f1689b-3ce4-435c-9b9d-3844861e5c05



---

With the fix from this PR: 

https://github.com/user-attachments/assets/29737a94-52e7-41d8-b6b1-6271eec0b38b

## Testing instructions

1. Switch the app to `0x29a/BB-9182/handle-locked-subsections-correctly` branch and build it locally.
2. Enroll your user in [this course](https://apps.lms.dev.eshe.edpl.us/learning/course/course-v1:BB-9182+BB-9182+BB-9182).
3. Launch the app in the emulator and try accessing the second subsection.

[private-ref](https://tasks.opencraft.com/browse/BB-9182)