### PR TITLE
fix: Make SSO login use JWT for better compatibility

### DIFF
--- a/auth/src/main/java/org/openedx/auth/data/api/AuthApi.kt
+++ b/auth/src/main/java/org/openedx/auth/data/api/AuthApi.kt
@@ -38,7 +38,9 @@ interface AuthApi {
         @Field("grant_type") grantType: String,
         @Field("client_id") clientId: String,
         @Field("code") code: String,
-        @Field("redirect_uri") redirectUri: String
+        @Field("redirect_uri") redirectUri: String,
+        @Field("token_type") tokenType: String,
+        @Field("asymmetric_jwt") isAsymmetricJwt: Boolean = true,
     ): AuthResponse
 
     @FormUrlEncoded

--- a/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
+++ b/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
@@ -48,7 +48,8 @@ class AuthRepository(
             grantType = ApiConstants.GRANT_TYPE_CODE,
             clientId = config.getOAuthClientId(),
             code = code,
-            redirectUri = "${config.getApplicationID()}://oauth2Callback"
+            redirectUri = "${config.getApplicationID()}://oauth2Callback",
+            tokenType = config.getAccessTokenType(),
         ).mapToDomain().processAuthResponse()
     }
 


### PR DESCRIPTION
While testing the [upstream PR](https://github.com/openedx/openedx-app-android/pull/371) for this I found that we can easily switch to JWT tokens by requesting a JWT token. 