### PR TITLE
chore: cherry-pick eshe specific customizations to sumac.3

### DIFF
--- a/app/src/main/java/org/openedx/app/MainFragment.kt
+++ b/app/src/main/java/org/openedx/app/MainFragment.kt
@@ -50,11 +50,6 @@ class MainFragment : Fragment(R.layout.fragment_main) {
                     binding.viewPager.setCurrentItem(0, false)
                 }
 
-                R.id.fragmentDiscover -> {
-                    viewModel.logDiscoveryTabClickedEvent()
-                    binding.viewPager.setCurrentItem(1, false)
-                }
-
                 R.id.fragmentProfile -> {
                     viewModel.logProfileTabClickedEvent()
                     binding.viewPager.setCurrentItem(2, false)
@@ -68,9 +63,9 @@ class MainFragment : Fragment(R.layout.fragment_main) {
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.navigateToDiscovery.collect { shouldNavigateToDiscovery ->
-                if (shouldNavigateToDiscovery) {
-                    binding.bottomNavView.selectedItemId = R.id.fragmentDiscover
+            viewModel.navigateToHome.collect { shouldNavigateToHome ->
+                if (shouldNavigateToHome) {
+                    binding.bottomNavView.selectedItemId = R.id.fragmentLearn
                 }
             }
         }
@@ -92,13 +87,6 @@ class MainFragment : Fragment(R.layout.fragment_main) {
 
             when (requireArguments().getString(ARG_OPEN_TAB, "")) {
                 HomeTab.LEARN.name,
-                HomeTab.PROGRAMS.name -> {
-                    binding.bottomNavView.selectedItemId = R.id.fragmentLearn
-                }
-
-                HomeTab.DISCOVER.name -> {
-                    binding.bottomNavView.selectedItemId = R.id.fragmentDiscover
-                }
 
                 HomeTab.PROFILE.name -> {
                     binding.bottomNavView.selectedItemId = R.id.fragmentProfile
@@ -114,14 +102,9 @@ class MainFragment : Fragment(R.layout.fragment_main) {
         binding.viewPager.offscreenPageLimit = 4
 
         val openTab = requireArguments().getString(ARG_OPEN_TAB, HomeTab.LEARN.name)
-        val learnTab = if (openTab == HomeTab.PROGRAMS.name) {
-            LearnTab.PROGRAMS
-        } else {
-            LearnTab.COURSES
-        }
+        val learnTab = LearnTab.COURSES
         adapter = NavigationFragmentAdapter(this).apply {
             addFragment(LearnFragment.newInstance(openTab = learnTab.name))
-            addFragment(viewModel.getDiscoveryFragment)
             addFragment(ProfileFragment())
         }
         binding.viewPager.adapter = adapter

--- a/app/src/main/java/org/openedx/app/MainViewModel.kt
+++ b/app/src/main/java/org/openedx/app/MainViewModel.kt
@@ -26,9 +26,9 @@ class MainViewModel(
     val isBottomBarEnabled: LiveData<Boolean>
         get() = _isBottomBarEnabled
 
-    private val _navigateToDiscovery = MutableSharedFlow<Boolean>()
-    val navigateToDiscovery: SharedFlow<Boolean>
-        get() = _navigateToDiscovery.asSharedFlow()
+    private val _navigateToHome = MutableSharedFlow<Boolean>()
+    val navigateToHome: SharedFlow<Boolean>
+        get() = _navigateToHome.asSharedFlow()
 
     val isDiscoveryTypeWebView get() = config.getDiscoveryConfig().isViewTypeWebView()
     val getDiscoveryFragment get() = DiscoveryNavigator(isDiscoveryTypeWebView).getDiscoveryFragment()
@@ -38,7 +38,7 @@ class MainViewModel(
         notifier.notifier
             .onEach {
                 if (it is NavigationToDiscovery) {
-                    _navigateToDiscovery.emit(true)
+                    _navigateToHome.emit(true)
                 }
             }
             .distinctUntilChanged()

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -293,6 +293,7 @@ val screenModule = module {
             get(),
             get(),
             get(),
+            get(),
         )
     }
     viewModel { (courseId: String, unitId: String) ->

--- a/app/src/main/res/menu/bottom_view_menu.xml
+++ b/app/src/main/res/menu/bottom_view_menu.xml
@@ -8,12 +8,6 @@
         android:title="@string/app_navigation_learn" />
 
     <item
-        android:id="@+id/fragmentDiscover"
-        android:enabled="true"
-        android:icon="@drawable/app_ic_home"
-        android:title="@string/app_navigation_discovery" />
-
-    <item
         android:id="@+id/fragmentProfile"
         android:enabled="true"
         android:icon="@drawable/app_ic_profile"

--- a/core/src/main/java/org/openedx/core/config/AgreementUrlsConfig.kt
+++ b/core/src/main/java/org/openedx/core/config/AgreementUrlsConfig.kt
@@ -14,6 +14,8 @@ internal data class AgreementUrlsConfig(
     private val dataSellConsentUrl: String = "",
     @SerializedName("TOS_URL")
     private val tosUrl: String = "",
+    @SerializedName("CONTACT_SUPPORT_URL")
+    private val contactSupportUrl: String = "",
     @SerializedName("EULA_URL")
     private val eulaUrl: String = "",
     @SerializedName("SUPPORTED_LANGUAGES")
@@ -25,6 +27,7 @@ internal data class AgreementUrlsConfig(
             cookiePolicyUrl = cookiePolicyUrl,
             dataSellConsentUrl = dataSellConsentUrl,
             tosUrl = tosUrl,
+            contactSupportUrl = contactSupportUrl,
             eulaUrl = eulaUrl,
             supportedLanguages = supportedLanguages,
         )
@@ -35,6 +38,7 @@ internal data class AgreementUrlsConfig(
                     cookiePolicyUrl = cookiePolicyUrl.appendLocale(it),
                     dataSellConsentUrl = dataSellConsentUrl.appendLocale(it),
                     tosUrl = tosUrl.appendLocale(it),
+                    contactSupportUrl = contactSupportUrl.appendLocale(it),
                     eulaUrl = eulaUrl.appendLocale(it),
                     supportedLanguages = supportedLanguages,
                 )

--- a/core/src/main/java/org/openedx/core/data/api/CourseApi.kt
+++ b/core/src/main/java/org/openedx/core/data/api/CourseApi.kt
@@ -12,6 +12,7 @@ import org.openedx.core.data.model.CourseStructureModel
 import org.openedx.core.data.model.EnrollmentStatus
 import org.openedx.core.data.model.HandoutsModel
 import org.openedx.core.data.model.ResetCourseDates
+import org.openedx.core.data.model.SequenceModel
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -100,4 +101,7 @@ interface CourseApi {
     suspend fun getEnrollmentDetails(
         @Path("course_id") courseId: String,
     ): CourseEnrollmentDetails
+
+    @GET("api/courseware/sequence/{sequence_id}/")
+    suspend fun getSequence(@Path("sequence_id") sequenceId: String): SequenceModel
 }

--- a/core/src/main/java/org/openedx/core/data/model/GatedContentModel.kt
+++ b/core/src/main/java/org/openedx/core/data/model/GatedContentModel.kt
@@ -1,0 +1,27 @@
+package org.openedx.core.data.model
+
+import com.google.gson.annotations.SerializedName
+import org.openedx.core.domain.model.GatedContent
+
+data class GatedContentModel(
+    @SerializedName("prereq_id")
+    val prereqId: String?,
+    @SerializedName("prereq_url")
+    val prereqUrl: String?,
+    @SerializedName("prereq_section_name")
+    val prereqSectionName: String?,
+    @SerializedName("gated")
+    val gated: Boolean,
+    @SerializedName("gated_section_name")
+    val gatedSectionName: String?,
+) {
+    fun mapToDomain(): GatedContent {
+        return GatedContent(
+            prereqId = prereqId,
+            prereqUrl = prereqUrl,
+            prereqSubsectionName = prereqSectionName,
+            gated = gated,
+            gatedSubsectionName = gatedSectionName
+        )
+    }
+}

--- a/core/src/main/java/org/openedx/core/data/model/SequenceModel.kt
+++ b/core/src/main/java/org/openedx/core/data/model/SequenceModel.kt
@@ -1,0 +1,30 @@
+package org.openedx.core.data.model
+
+import com.google.gson.annotations.SerializedName
+import org.openedx.core.domain.model.Subsection
+
+data class SequenceModel(
+    @SerializedName("element_id")
+    val elementId: String,
+    @SerializedName("item_id")
+    val itemId: String,
+    @SerializedName("banner_text")
+    val bannerText: String?,
+    @SerializedName("gated_content")
+    val gatedContentModel: GatedContentModel,
+    @SerializedName("sequence_name")
+    val sequenceName: String,
+    @SerializedName("display_name")
+    val displayName: String,
+) {
+    fun mapToDomain(): Subsection {
+        return Subsection(
+            elementId = elementId,
+            itemId = itemId,
+            bannerText = bannerText,
+            subsectionName = sequenceName,
+            displayName = displayName,
+            gatedContent = gatedContentModel.mapToDomain(),
+        )
+    }
+}

--- a/core/src/main/java/org/openedx/core/domain/model/AgreementUrls.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/AgreementUrls.kt
@@ -17,6 +17,7 @@ internal data class Agreement(
 
 data class AgreementUrls(
     val privacyPolicyUrl: String = "",
+    val contactSupportUrl: String = "",
     val cookiePolicyUrl: String = "",
     val dataSellConsentUrl: String = "",
     val tosUrl: String = "",

--- a/core/src/main/java/org/openedx/core/domain/model/GatedContent.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/GatedContent.kt
@@ -1,0 +1,13 @@
+package org.openedx.core.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class GatedContent(
+    val prereqId: String?,
+    val prereqUrl: String?,
+    val prereqSubsectionName: String?,
+    val gated: Boolean,
+    val gatedSubsectionName: String?
+) : Parcelable

--- a/core/src/main/java/org/openedx/core/domain/model/Progress.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/Progress.kt
@@ -3,6 +3,7 @@ package org.openedx.core.domain.model
 import android.os.Parcelable
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
+import org.openedx.core.extension.safeDivBy
 
 @Parcelize
 data class Progress(
@@ -11,11 +12,7 @@ data class Progress(
 ) : Parcelable {
 
     @IgnoredOnParcel
-    val value: Float = try {
-        assignmentsCompleted.toFloat() / totalAssignmentsCount.toFloat()
-    } catch (_: ArithmeticException) {
-        0f
-    }
+    val value: Float = assignmentsCompleted.toFloat().safeDivBy(totalAssignmentsCount.toFloat())
 
     companion object {
         val DEFAULT_PROGRESS = Progress(0, 0)

--- a/core/src/main/java/org/openedx/core/domain/model/Subsection.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/Subsection.kt
@@ -1,0 +1,14 @@
+package org.openedx.core.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Subsection(
+    val elementId: String,
+    val itemId: String,
+    val bannerText: String?,
+    val gatedContent: GatedContent,
+    val subsectionName: String,
+    val displayName: String
+) : Parcelable

--- a/core/src/main/java/org/openedx/core/extension/FloatExt.kt
+++ b/core/src/main/java/org/openedx/core/extension/FloatExt.kt
@@ -1,0 +1,19 @@
+package org.openedx.core.extension
+
+/**
+ * Safely divides this Float by [divisor], returning 0f if:
+ *  - [divisor] is zero,
+ *  - the result is NaN.
+ *
+ * Workaround for accessibility issue:
+ * https://github.com/openedx/openedx-app-android/issues/442
+ */
+fun Float.safeDivBy(divisor: Float): Float = try {
+    var result = this / divisor
+    if (result.isNaN()) {
+        result = 0f
+    }
+    result
+} catch (_: ArithmeticException) {
+    0f
+}

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="core_data_sell" translatable="false">Do not sell my personal information</string>
     <string name="core_faq" translatable="false">View FAQ</string>
     <string name="core_terms_of_use">Terms of Use</string>
+    <string name="core_contact_support">Contact Support</string>
     <string name="core_profile">Profile</string>
     <string name="core_cancel">Cancel</string>
     <string name="core_search">Search</string>

--- a/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
+++ b/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
@@ -139,4 +139,6 @@ class CourseRepository(
             downloadDao.removeOfflineXBlockProgress(listOf(blockId))
         }
     }
+
+    suspend fun getSequence(sectionId: String) = api.getSequence(sectionId).mapToDomain()
 }

--- a/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
+++ b/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
@@ -140,5 +140,5 @@ class CourseRepository(
         }
     }
 
-    suspend fun getSequence(sectionId: String) = api.getSequence(sectionId).mapToDomain()
+    suspend fun getSequence(sequenceId: String) = api.getSequence(sequenceId).mapToDomain()
 }

--- a/course/src/main/java/org/openedx/course/domain/interactor/CourseInteractor.kt
+++ b/course/src/main/java/org/openedx/course/domain/interactor/CourseInteractor.kt
@@ -82,6 +82,8 @@ class CourseInteractor(
 
     suspend fun removeDownloadModel(id: String) = repository.removeDownloadModel(id)
 
+    suspend fun getSubsection(subsectionId: String) = repository.getSequence(subsectionId)
+
     fun getDownloadModels() = repository.getDownloadModels()
 
     suspend fun getAllDownloadModels() = repository.getAllDownloadModels()

--- a/course/src/main/java/org/openedx/course/presentation/CourseAnalytics.kt
+++ b/course/src/main/java/org/openedx/course/presentation/CourseAnalytics.kt
@@ -78,6 +78,10 @@ enum class CourseAnalyticsEvent(val eventName: String, val biValue: String) {
         "Course:Unit Detail",
         "edx.bi.app.course.unit_detail"
     ),
+    PREREQUISITE(
+        "Course:Prerequisite",
+        "edx.bi.app.course.prerequisite"
+    ),
     VIEW_CERTIFICATE(
         "Course:View Certificate Clicked",
         "edx.bi.app.course.view_certificate.clicked"

--- a/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import org.openedx.core.BlockType
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Block
+import org.openedx.core.extension.safeDivBy
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
 import org.openedx.core.module.db.DownloadModel
@@ -187,19 +188,24 @@ class CourseOfflineViewModel(
         completedDownloads: List<DownloadModel>,
         downloadedBlocks: List<Block>
     ) {
-        val downloadedSize = getFilesSize(downloadedBlocks)
+        val downloadedSize = getFilesSize(downloadedBlocks).toFloat()
         val realDownloadedSize = completedDownloads.sumOf { it.size }
         val largestDownloads = completedDownloads
             .sortedByDescending { it.size }
             .take(n = 5)
-
+        val progressBarValue = downloadedSize.safeDivBy(totalDownloadableSize.toFloat())
+        val readyToDownloadSize = if (progressBarValue >= 1) {
+            0
+        } else {
+            totalDownloadableSize - realDownloadedSize
+        }
         _uiState.update {
             it.copy(
                 isHaveDownloadableBlocks = true,
                 largestDownloads = largestDownloads,
-                readyToDownloadSize = (totalDownloadableSize - downloadedSize).toFileSize(1, false),
+                readyToDownloadSize = readyToDownloadSize.toFileSize(1, false),
                 downloadedSize = realDownloadedSize.toFileSize(1, false),
-                progressBarValue = downloadedSize.toFloat() / totalDownloadableSize.toFloat()
+                progressBarValue = progressBarValue
             )
         }
     }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -253,6 +255,34 @@ private fun CourseSectionScreen(
                                 contentAlignment = Alignment.Center
                             ) {
                                 CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                            }
+                        }
+
+                        is CourseSectionUIState.Gated -> {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.Center,
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Image(
+                                    painter = painterResource(id = R.drawable.ic_course_gated),
+                                    contentDescription = "gated",
+                                    modifier = Modifier.size(48.dp)
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                                Text(
+                                    modifier = Modifier
+                                        .padding(horizontal = 16.dp)
+                                        .fillMaxWidth(),
+                                    text = stringResource(
+                                        id = R.string.course_gated_subsection,
+                                        uiState.prereqSubsectionName ?: ""
+                                    ),
+                                    textAlign = TextAlign.Center,
+                                    style = MaterialTheme.appTypography.titleMedium,
+                                    color = MaterialTheme.appColors.textPrimary,
+
+                                )
                             }
                         }
 

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -63,6 +63,7 @@ import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.presentation.course.CourseViewMode
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
+import org.openedx.core.ui.OpenEdXButton
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -126,6 +127,15 @@ class CourseSectionFragment : Fragment() {
                             )
                         }
                     },
+                    onGoToPrerequisiteClick = { subSectionId ->
+                        viewModel.goToPrerequisiteSectionClickedEvent(subSectionId)
+                        router.navigateToCourseSubsections(
+                            fm = requireActivity().supportFragmentManager,
+                            courseId = viewModel.courseId,
+                            subSectionId = subSectionId,
+                            mode = CourseViewMode.FULL
+                        )
+                    }
                 )
 
                 LaunchedEffect(rememberSaveable { true }) {
@@ -178,6 +188,7 @@ private fun CourseSectionScreen(
     uiMessage: UIMessage?,
     onBackClick: () -> Unit,
     onItemClick: (Block) -> Unit,
+    onGoToPrerequisiteClick: (String) -> Unit
 ) {
     val scaffoldState = rememberScaffoldState()
     val title = when (uiState) {
@@ -281,7 +292,14 @@ private fun CourseSectionScreen(
                                     textAlign = TextAlign.Center,
                                     style = MaterialTheme.appTypography.titleMedium,
                                     color = MaterialTheme.appColors.textPrimary,
-
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                                OpenEdXButton(
+                                    text = stringResource(id = R.string.course_go_to_prerequisite_section),
+                                    onClick = {
+                                        onGoToPrerequisiteClick(uiState.prereqId ?: "")
+                                    },
+                                    modifier = Modifier.padding(top = 16.dp)
                                 )
                             }
                         }
@@ -391,6 +409,7 @@ private fun CourseSectionScreenPreview() {
             uiMessage = null,
             onBackClick = {},
             onItemClick = {},
+            onGoToPrerequisiteClick = {}
         )
     }
 }
@@ -415,6 +434,29 @@ private fun CourseSectionScreenTabletPreview() {
             uiMessage = null,
             onBackClick = {},
             onItemClick = {},
+            onGoToPrerequisiteClick = {}
+        )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.NEXUS_9)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, device = Devices.NEXUS_9)
+@Composable
+private fun CourseSectionScreenGatedPreview() {
+    OpenEdXTheme {
+        CourseSectionScreen(
+            windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
+            uiState = CourseSectionUIState.Gated(
+                "Gated Subsection",
+                "Prerequisite Subsection",
+                "Prerequisite Id"
+            ),
+            uiMessage = null,
+            onBackClick = {},
+            onItemClick = {},
+            onGoToPrerequisiteClick = {}
         )
     }
 }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
@@ -8,5 +8,9 @@ sealed class CourseSectionUIState {
         val sectionName: String,
         val courseName: String
     ) : CourseSectionUIState()
+    data class Gated(
+        val gatedSubsectionName: String?,
+        val prereqSubsectionName: String?,
+    ) : CourseSectionUIState()
     data object Loading : CourseSectionUIState()
 }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
@@ -11,6 +11,7 @@ sealed class CourseSectionUIState {
     data class Gated(
         val gatedSubsectionName: String?,
         val prereqSubsectionName: String?,
+        val prereqId: String?,
     ) : CourseSectionUIState()
     data object Loading : CourseSectionUIState()
 }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
@@ -54,6 +54,14 @@ class CourseSectionViewModel(
         _uiState.value = CourseSectionUIState.Loading
         viewModelScope.launch {
             try {
+                val sectionData = interactor.getSubsection(blockId)
+                if (sectionData.gatedContent.gated) {
+                    _uiState.value = CourseSectionUIState.Gated(
+                        gatedSubsectionName = sectionData.gatedContent.gatedSubsectionName,
+                        prereqSubsectionName = sectionData.gatedContent.prereqSubsectionName
+                    )
+                    return@launch
+                }
                 val courseStructure = when (mode) {
                     CourseViewMode.FULL -> interactor.getCourseStructure(courseId)
                     CourseViewMode.VIDEOS -> interactor.getCourseStructureForVideos(courseId)

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
@@ -57,9 +57,10 @@ class CourseSectionViewModel(
                 val sectionData = interactor.getSubsection(blockId)
                 if (sectionData.gatedContent.gated) {
                     _uiState.value = CourseSectionUIState.Gated(
+                        prereqId = sectionData.gatedContent.prereqId,
+                        prereqSubsectionName = sectionData.gatedContent.prereqSubsectionName,
                         gatedSubsectionName = sectionData.gatedContent.gatedSubsectionName,
-                        prereqSubsectionName = sectionData.gatedContent.prereqSubsectionName
-                    )
+                        )
                     return@launch
                 }
                 val courseStructure = when (mode) {
@@ -121,6 +122,21 @@ class CourseSectionViewModel(
                     put(CourseAnalyticsKey.NAME.key, CourseAnalyticsEvent.UNIT_DETAIL.biValue)
                     put(CourseAnalyticsKey.COURSE_ID.key, courseId)
                     put(CourseAnalyticsKey.BLOCK_ID.key, blockId)
+                    put(CourseAnalyticsKey.CATEGORY.key, CourseAnalyticsKey.NAVIGATION.key)
+                }
+            )
+        }
+    }
+
+    fun goToPrerequisiteSectionClickedEvent(subSectionId: String) {
+        val currentState = uiState.value
+        if (currentState is CourseSectionUIState.Gated) {
+            analytics.logEvent(
+                event = CourseAnalyticsEvent.PREREQUISITE.eventName,
+                params = buildMap {
+                    put(CourseAnalyticsKey.NAME.key, CourseAnalyticsEvent.PREREQUISITE.biValue)
+                    put(CourseAnalyticsKey.COURSE_ID.key, courseId)
+                    put(CourseAnalyticsKey.BLOCK_ID.key, subSectionId)
                     put(CourseAnalyticsKey.CATEGORY.key, CourseAnalyticsKey.NAVIGATION.key)
                 }
             )

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionViewModel.kt
@@ -9,6 +9,7 @@ import org.openedx.core.BlockType
 import org.openedx.core.R
 import org.openedx.core.domain.model.Block
 import org.openedx.core.presentation.course.CourseViewMode
+import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseSectionChanged
 import org.openedx.course.domain.interactor.CourseInteractor
@@ -25,6 +26,7 @@ class CourseSectionViewModel(
     val courseId: String,
     private val interactor: CourseInteractor,
     private val resourceManager: ResourceManager,
+    private val networkConnection: NetworkConnection,
     private val notifier: CourseNotifier,
     private val analytics: CourseAnalytics,
 ) : BaseViewModel() {
@@ -54,14 +56,16 @@ class CourseSectionViewModel(
         _uiState.value = CourseSectionUIState.Loading
         viewModelScope.launch {
             try {
-                val sectionData = interactor.getSubsection(blockId)
-                if (sectionData.gatedContent.gated) {
-                    _uiState.value = CourseSectionUIState.Gated(
-                        prereqId = sectionData.gatedContent.prereqId,
-                        prereqSubsectionName = sectionData.gatedContent.prereqSubsectionName,
-                        gatedSubsectionName = sectionData.gatedContent.gatedSubsectionName,
+                if (networkConnection.isOnline()) {
+                    val sectionData = interactor.getSubsection(blockId)
+                    if (sectionData.gatedContent.gated) {
+                        _uiState.value = CourseSectionUIState.Gated(
+                            prereqId = sectionData.gatedContent.prereqId,
+                            prereqSubsectionName = sectionData.gatedContent.prereqSubsectionName,
+                            gatedSubsectionName = sectionData.gatedContent.gatedSubsectionName,
                         )
-                    return@launch
+                        return@launch
+                    }
                 }
                 val courseStructure = when (mode) {
                     CourseViewMode.FULL -> interactor.getCourseStructure(courseId)

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -84,6 +84,7 @@ import org.openedx.core.domain.model.AssignmentProgress
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseDatesBannerInfo
+import org.openedx.core.extension.safeDivBy
 import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.FileType
@@ -260,11 +261,7 @@ fun OfflineQueueCard(
                 maxLines = 1
             )
 
-            val progress = if (progressSize == 0L) {
-                0f
-            } else {
-                progressValue.toFloat() / progressSize
-            }
+            val progress = progressValue.toFloat().safeDivBy(progressSize.toFloat())
             LinearProgressIndicator(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="course_resume">Resume</string>
     <string name="course_to_proceed">To proceed with \"%s\" press \"Next section\".</string>
     <string name="course_gated_content_label">Some content in this part of the course is locked for upgraded users only.</string>
+    <string name="course_gated_subsection">Content locked. You must complete the prerequisite: \“%s\” to access this content.</string>
     <string name="course_change_quality_when_downloading">You cannot change the download video quality when all videos are downloading</string>
     <string name="course_dates_shifted_message">Dates Shifted</string>
 

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="course_to_proceed">To proceed with \"%s\" press \"Next section\".</string>
     <string name="course_gated_content_label">Some content in this part of the course is locked for upgraded users only.</string>
     <string name="course_gated_subsection">Content locked. You must complete the prerequisite: \“%s\” to access this content.</string>
+    <string name="course_go_to_prerequisite_section">Go To Prerequisite Section</string>
     <string name="course_change_quality_when_downloading">You cannot change the download video quality when all videos are downloading</string>
     <string name="course_dates_shifted_message">Dates Shifted</string>
 

--- a/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
@@ -228,6 +228,7 @@ class CourseSectionViewModelTest {
             "",
             interactor,
             resourceManager,
+            networkConnection,
             notifier,
             analytics,
         )
@@ -255,6 +256,7 @@ class CourseSectionViewModelTest {
             "",
             interactor,
             resourceManager,
+            networkConnection,
             notifier,
             analytics,
         )
@@ -284,6 +286,7 @@ class CourseSectionViewModelTest {
             "",
             interactor,
             resourceManager,
+            networkConnection,
             notifier,
             analytics,
         )
@@ -313,6 +316,7 @@ class CourseSectionViewModelTest {
             "",
             interactor,
             resourceManager,
+            networkConnection,
             notifier,
             analytics,
         )
@@ -335,6 +339,7 @@ class CourseSectionViewModelTest {
             "",
             interactor,
             resourceManager,
+            networkConnection,
             notifier,
             analytics,
         )
@@ -360,6 +365,7 @@ class CourseSectionViewModelTest {
             "",
             interactor,
             resourceManager,
+            networkConnection,
             notifier,
             analytics,
         )
@@ -388,6 +394,7 @@ class CourseSectionViewModelTest {
             "",
             interactor,
             resourceManager,
+            networkConnection,
             notifier,
             analytics,
         )

--- a/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
@@ -31,6 +31,8 @@ import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseStructure
 import org.openedx.core.domain.model.CoursewareAccess
+import org.openedx.core.domain.model.GatedContent
+import org.openedx.core.domain.model.Subsection
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
 import org.openedx.core.module.db.DownloadModel
@@ -161,6 +163,36 @@ class CourseSectionViewModelTest {
         progress = null
     )
 
+    private val subsection = Subsection(
+        elementId = "id",
+        itemId = "id",
+        bannerText = "bannerText",
+        gatedContent = GatedContent(
+            prereqId = null,
+            prereqUrl = null,
+            prereqSubsectionName = null,
+            gated = false,
+            gatedSubsectionName = null
+        ),
+        subsectionName = "subsectionName",
+        displayName = "displayName"
+    )
+
+    private val gatedSubsection = Subsection(
+        elementId = "id",
+        itemId = "id",
+        bannerText = "bannerText",
+        gatedContent = GatedContent(
+            prereqId = "prereqId",
+            prereqUrl = "prereqUrl",
+            prereqSubsectionName = "prereqSubsectionName",
+            gated = true,
+            gatedSubsectionName = "gatedSubsectionName"
+        ),
+        subsectionName = "subsectionName",
+        displayName = "displayName"
+    )
+
     private val downloadModel = DownloadModel(
         "id",
         "title",
@@ -181,6 +213,7 @@ class CourseSectionViewModelTest {
         every {
             resourceManager.getString(org.openedx.course.R.string.course_can_download_only_with_wifi)
         } returns cantDownload
+        coEvery { interactor.getSubsection("id") } returns subsection
     }
 
     @After
@@ -199,13 +232,15 @@ class CourseSectionViewModelTest {
             analytics,
         )
 
+        coEvery { interactor.getSubsection("") } throws UnknownHostException()
         coEvery { interactor.getCourseStructure(any()) } throws UnknownHostException()
         coEvery { interactor.getCourseStructureForVideos(any()) } throws UnknownHostException()
 
         viewModel.getBlocks("", CourseViewMode.FULL)
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { interactor.getCourseStructure(any()) }
+        coVerify(exactly = 1) { interactor.getSubsection("") }
+        coVerify(exactly = 0) { interactor.getCourseStructure(any()) }
         coVerify(exactly = 0) { interactor.getCourseStructureForVideos(any()) }
 
         val message = viewModel.uiMessage.value as? UIMessage.SnackBarMessage
@@ -224,13 +259,15 @@ class CourseSectionViewModelTest {
             analytics,
         )
 
+        coEvery { interactor.getSubsection("id2") } throws Exception()
         coEvery { interactor.getCourseStructure(any()) } throws Exception()
         coEvery { interactor.getCourseStructureForVideos(any()) } throws Exception()
 
         viewModel.getBlocks("id2", CourseViewMode.FULL)
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { interactor.getCourseStructure(any()) }
+        coVerify(exactly = 1) { interactor.getSubsection("id2") }
+        coVerify(exactly = 0) { interactor.getCourseStructure(any()) }
         coVerify(exactly = 0) { interactor.getCourseStructureForVideos(any()) }
 
         val message = viewModel.uiMessage.value as? UIMessage.SnackBarMessage
@@ -340,5 +377,26 @@ class CourseSectionViewModelTest {
         advanceUntilIdle()
 
         assert(viewModel.uiState.value is CourseSectionUIState.Blocks)
+    }
+
+    @Test
+    fun `subsection is gated`() = runTest {
+        coEvery { downloadDao.getAllDataFlow() } returns flow {
+            emit(listOf(DownloadModelEntity.createFrom(downloadModel)))
+        }
+        val viewModel = CourseSectionViewModel(
+            "",
+            interactor,
+            resourceManager,
+            notifier,
+            analytics,
+        )
+
+        coEvery { interactor.getSubsection("id") } returns gatedSubsection
+
+        viewModel.getBlocks("id", CourseViewMode.FULL)
+        advanceUntilIdle()
+
+        assert(viewModel.uiState.value is CourseSectionUIState.Gated)
     }
 }

--- a/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
@@ -213,6 +213,7 @@ class CourseSectionViewModelTest {
         every {
             resourceManager.getString(org.openedx.course.R.string.course_can_download_only_with_wifi)
         } returns cantDownload
+        every { networkConnection.isOnline() } returns true
         coEvery { interactor.getSubsection("id") } returns subsection
     }
 

--- a/dashboard/src/main/java/org/openedx/courses/presentation/AllEnrolledCoursesView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/AllEnrolledCoursesView.kt
@@ -431,16 +431,11 @@ fun CourseItem(
                         .fillMaxWidth()
                         .height(90.dp)
                 )
-                val progress: Float = try {
-                    course.progress.assignmentsCompleted.toFloat() / course.progress.totalAssignmentsCount.toFloat()
-                } catch (_: ArithmeticException) {
-                    0f
-                }
                 LinearProgressIndicator(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(8.dp),
-                    progress = progress,
+                    progress = course.progress.value,
                     color = MaterialTheme.appColors.primary,
                     backgroundColor = MaterialTheme.appColors.divider
                 )

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -557,17 +557,12 @@ private fun PrimaryCourseCard(
                     .fillMaxWidth()
                     .height(140.dp)
             )
-            val progress: Float = try {
-                primaryCourse.progress.assignmentsCompleted.toFloat() /
-                        primaryCourse.progress.totalAssignmentsCount.toFloat()
-            } catch (_: ArithmeticException) {
-                0f
-            }
+
             LinearProgressIndicator(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(8.dp),
-                progress = progress,
+                progress = primaryCourse.progress.value,
                 color = MaterialTheme.appColors.primary,
                 backgroundColor = MaterialTheme.appColors.divider
             )

--- a/default_config/dev/config.yaml
+++ b/default_config/dev/config.yaml
@@ -11,7 +11,8 @@ AGREEMENT_URLS:
   PRIVACY_POLICY_URL: ''
   COOKIE_POLICY_URL: ''
   DATA_SELL_CONSENT_URL: ''
-  TOS_URL: ''
+  CONTACT_SUPPORT_URL: 'https://eshemoeasu.my.site.com/help/s/'
+  TOS_URL: 'https://courses.ethernet.edu.et/terms'
   EULA_URL: ''
   SUPPORTED_LANGUAGES: [ ] #en is default language
 

--- a/profile/src/main/java/org/openedx/profile/presentation/profile/compose/ProfileView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/profile/compose/ProfileView.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.openedx.core.R
 import org.openedx.core.ui.HandleUIMessage
-import org.openedx.core.ui.OpenEdXOutlinedButton
 import org.openedx.core.ui.Toolbar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.statusBarsInset
@@ -143,17 +142,6 @@ internal fun ProfileView(
                                         subtitle = "@${uiState.account.username}"
                                     )
                                     ProfileInfoSection(uiState.account)
-                                    OpenEdXOutlinedButton(
-                                        modifier = Modifier
-                                            .fillMaxWidth(),
-                                        text = stringResource(id = org.openedx.profile.R.string.profile_edit_profile),
-                                        onClick = {
-                                            onAction(ProfileViewAction.EditAccountClick)
-                                        },
-                                        borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                                        textColor = MaterialTheme.appColors.textAccent
-                                    )
-                                    Spacer(modifier = Modifier.height(12.dp))
                                 }
                             }
                         }

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsFragment.kt
@@ -68,7 +68,9 @@ class SettingsFragment : Fragment() {
                             SettingsScreenAction.FaqClick -> viewModel.faqClicked()
 
                             SettingsScreenAction.SupportClick -> {
-                                viewModel.emailSupportClicked(requireContext())
+                                viewModel.emailSupportClicked(
+                                    requireActivity().supportFragmentManager
+                                )
                             }
 
                             SettingsScreenAction.TermsClick -> {

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
@@ -167,12 +167,6 @@ internal fun SettingsScreen(
                                         .verticalScroll(rememberScrollState()),
                                     horizontalAlignment = Alignment.CenterHorizontally
                                 ) {
-                                    Spacer(Modifier.height(30.dp))
-
-                                    ManageAccountSection(onManageAccountClick = {
-                                        onAction(SettingsScreenAction.ManageAccountClick)
-                                    })
-
                                     Spacer(modifier = Modifier.height(24.dp))
 
                                     SettingsSection(
@@ -244,24 +238,6 @@ private fun SettingsSection(
 }
 
 @Composable
-private fun ManageAccountSection(onManageAccountClick: () -> Unit) {
-    Column {
-        Card(
-            shape = MaterialTheme.appShapes.cardShape,
-            elevation = 0.dp,
-            backgroundColor = MaterialTheme.appColors.cardViewBackground
-        ) {
-            Column(Modifier.fillMaxWidth()) {
-                SettingsItem(
-                    text = stringResource(id = R.string.core_manage_account),
-                    onClick = onManageAccountClick
-                )
-            }
-        }
-    }
-}
-
-@Composable
 private fun SupportInfoSection(
     uiState: SettingsUIState.Data,
     appUpgradeEvent: AppUpgradeEvent?,
@@ -282,7 +258,7 @@ private fun SupportInfoSection(
             backgroundColor = MaterialTheme.appColors.cardViewBackground
         ) {
             Column(Modifier.fillMaxWidth()) {
-                if (uiState.configuration.supportEmail.isNotBlank()) {
+                if (uiState.configuration.agreementUrls.contactSupportUrl.isNotBlank()) {
                     SettingsItem(text = stringResource(id = profileR.string.profile_contact_support)) {
                         onAction(SettingsScreenAction.SupportClick)
                     }

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsViewModel.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsViewModel.kt
@@ -23,7 +23,6 @@ import org.openedx.core.system.AppCookieManager
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.AppUpgradeEvent
 import org.openedx.core.system.notifier.app.LogoutEvent
-import org.openedx.core.utils.EmailUtil
 import org.openedx.foundation.extension.isInternetError
 import org.openedx.foundation.presentation.BaseViewModel
 import org.openedx.foundation.presentation.UIMessage
@@ -182,11 +181,11 @@ class SettingsViewModel(
         logProfileEvent(ProfileAnalyticsEvent.TERMS_OF_USE_CLICKED)
     }
 
-    fun emailSupportClicked(context: Context) {
-        EmailUtil.showFeedbackScreen(
-            context = context,
-            feedbackEmailAddress = config.getFeedbackEmailAddress(),
-            appVersion = appData.versionName
+    fun emailSupportClicked(fragmentManager: FragmentManager) {
+        profileRouter.navigateToWebContent(
+            fm = fragmentManager,
+            title = resourceManager.getString(R.string.core_contact_support),
+            url = configuration.agreementUrls.contactSupportUrl,
         )
         logProfileEvent(ProfileAnalyticsEvent.CONTACT_SUPPORT_CLICKED)
     }


### PR DESCRIPTION
## Description

The PR:
1. Cherry-picks eshe specific customizations on to sumac.3 from [eSHE's sumac.2 branch](https://github.com/open-craft/openedx-app-android/commits/eshe-mvp-release/sumac.2/). More details below.
2. Backports a bug fix from upstream.

Here's a list of code drifts and their status:

|Commit|Cherry Picked|Comments|
|---|:---:|---|
|[chore: remove client's oauth credentials from public repo](https://github.com/open-craft/openedx-app-android/commit/d5a2c491dbf49edc388828bf92f60e89542fc051)|:x:|Not required anymore. Configs moved to [android-app-config](https://gitlab.com/opencraft/client/asu-moe/android-app-config)|
|[chore: bump github upload-artifact action to v4](https://github.com/open-craft/openedx-app-android/commit/c744d2d8e6e613ae169d35ab03a774ca26fe3b2d)|:x:|Not required anymore. Upstream fixed it via [PR#401](https://github.com/openedx/openedx-app-android/pull/401)|
|[fixup! fix: downloaded videos were not working due to gating API needing online access](https://github.com/open-craft/openedx-app-android/commit/885c26feeb64f8e5beb49c1801180883da3c29ab)|:white_check_mark:||
|[fix: downloaded videos were not working due to gating API needing online access](https://github.com/open-craft/openedx-app-android/commit/9befe5f88348bd5f6d1ce36fdb736a264408c94b)|:white_check_mark:||
|[fix: Make SSO login use JWT for better compatibility](https://github.com/open-craft/openedx-app-android/commit/22201ee49c36f0ea3cb9eefbc9bc4f120e97e060)|:x:|Upstreamed - [PR#371](https://github.com/openedx/openedx-app-android/pull/371)|
|[feat: "Go To Prerequisite Section" button and previews](https://github.com/open-craft/openedx-app-android/commit/442c393be46471c9afe44ba50dd07ce59393c861)|:white_check_mark:||
|[feat: add "Gated" UI state for subsections](https://github.com/open-craft/openedx-app-android/commit/02bc3da82196be84beaca30470c928cfd9a58a43)|:white_check_mark:||
|[feat: add flag to remove registration from app (#9)](https://github.com/open-craft/openedx-app-android/commit/31215ab97734762a744a0c876339abe9fb652584)|:x:|Upstreamed - [PR#387](https://github.com/openedx/openedx-app-android/pull/387)|
|[fix: making imageUrl independent of API_HOST_URL formatting](https://github.com/open-craft/openedx-app-android/commit/d2999e68d712e4cdc64f3438bfa65d8293e282e3)|:x:|Not required anymore. Upstream fixed it via [PR#346](https://github.com/openedx/openedx-app-android/pull/346)|
|[fix: Support pull to refresh for empty dashboard](https://github.com/open-craft/openedx-app-android/commit/f9412afb8277e11571ea2e0b1838bf16128d4254)|:x:|Upstreamed - [PR#375](https://github.com/openedx/openedx-app-android/pull/375)|
|[chore: configure for app to connect to dev instance](https://github.com/open-craft/openedx-app-android/commit/fdd77122599867543d08200796feb3954c6f6098)|:x:|Not required anymore. Configs moved to [android-app-config](android-app-config)|
|[feat: Adding the course number and course effort on the course cards](https://github.com/open-craft/openedx-app-android/commit/acb4b920c8265f0dac4ed736dd147fe2c9a8dcb8)|:x:|UI Layout changed. Need to speak to eSHE about reimplementing this|
|[fix: Fixing config file to correctly parse the API_HOST_URL](https://github.com/open-craft/openedx-app-android/commit/3b68eaf5c39c366f63bebf44f0d21a248d2dc4bd)|:x:|Not required anymore. Configs moved to [android-app-config](android-app-config)|
|[feat: Support for login and registration via a browser custom tab](https://github.com/open-craft/openedx-app-android/commit/6e630af128ea85dc0e3f752255ec3c0366c9742f)|:x:|Upstreamed - [PR#371](https://github.com/openedx/openedx-app-android/pull/371)|
|[feat: hide some options for the MVP](https://github.com/open-craft/openedx-app-android/commit/c6bc3ad299c5f689b17053ff12b4554ffb31781c)|:white_check_mark:||

## Other information

Private Ref : [BB-9799](https://tasks.opencraft.com/browse/BB-9799)
Companion PR : [android-app-config#6](https://gitlab.com/opencraft/client/asu-moe/android-app-config/-/merge_requests/6)